### PR TITLE
Improvement: Add no-labeled points to outliers

### DIFF
--- a/Sources/DBSCAN/DBSCAN.swift
+++ b/Sources/DBSCAN/DBSCAN.swift
@@ -82,14 +82,16 @@ public struct DBSCAN<Value: Equatable> {
 
         var clusters: [[Value]] = []
         var outliers: [Value] = []
-
-        for points in Dictionary(grouping: points, by: { $0.label }).values {
+        
+        let labeledPoints = points.filter { $0.label != nil }
+        for points in Dictionary(grouping: labeledPoints, by: { $0.label }).values {
             let values = points.map { $0.value }
-            if values.count == 1 {
-                outliers.append(contentsOf: values)
-            } else {
-                clusters.append(values)
-            }
+            clusters.append(values)
+        }
+        
+        let noLabelPoints = points.filter { $0.label == nil }
+        for point in noLabelPoints {
+            outliers.append(point.value)
         }
 
         return (clusters, outliers)

--- a/Sources/DBSCAN/DBSCAN.swift
+++ b/Sources/DBSCAN/DBSCAN.swift
@@ -82,16 +82,14 @@ public struct DBSCAN<Value: Equatable> {
 
         var clusters: [[Value]] = []
         var outliers: [Value] = []
-        
-        let labeledPoints = points.filter { $0.label != nil }
-        for points in Dictionary(grouping: labeledPoints, by: { $0.label }).values {
+
+        for (label, points) in Dictionary(grouping: points, by: { $0.label }) {
             let values = points.map { $0.value }
-            clusters.append(values)
-        }
-        
-        let noLabelPoints = points.filter { $0.label == nil }
-        for point in noLabelPoints {
-            outliers.append(point.value)
+            if label == nil {
+                outliers.append(contentsOf: values)
+            } else {
+                clusters.append(values)
+            }
         }
 
         return (clusters, outliers)

--- a/Tests/DBSCANTests/DBSCANTests.swift
+++ b/Tests/DBSCANTests/DBSCANTests.swift
@@ -23,7 +23,7 @@ final class DBSCANTests: XCTestCase {
         let dbscan = DBSCAN(input)
 
         #if swift(>=5.2)
-        let (clusters, outliers) = dbscan(epsilon: 10, minimumNumberOfPoints: 1, distanceFunction: euclideanDistance)
+        let (clusters, outliers) = dbscan(epsilon: 10, minimumNumberOfPoints: 2, distanceFunction: euclideanDistance)
         #else
         let (clusters, outliers) = dbscan.callAsFunction(epsilon: 10, minimumNumberOfPoints: 1, distanceFunction: euclideanDistance)
         #endif
@@ -37,7 +37,7 @@ final class DBSCANTests: XCTestCase {
         ])
 
         XCTAssertEqual(outliers.count, 1)
-        XCTAssertEqual(outliers[0], [300.0, 70.0, 20.0])
+        XCTAssertEqual(outliers.first, [300.0, 70.0, 20.0])
     }
 
     #if swift(>=5.3)
@@ -89,7 +89,7 @@ final class DBSCANTests: XCTestCase {
 
         measure {
             let ε: Double = 1_000_000
-            (clusters, outliers) = dbscan(epsilon: ε, minimumNumberOfPoints: 1, distanceFunction: haversineDistance)
+            (clusters, outliers) = dbscan(epsilon: ε, minimumNumberOfPoints: 2, distanceFunction: haversineDistance)
         }
 
         XCTAssertEqual(clusters.count, 12)


### PR DESCRIPTION
When using the parameter `minimumNumberOfPoints >= 2`, outliers are not correct.

Using sample code in Readme with `minimumNumberOfPoints: 3`, I got a result below: 
```
let (clusters, outliers) = dbscan(epsilon: 10,
                                    minimumNumberOfPoints: 3,
                                    distanceFunction: simd.distance)

// clusters
[[SIMD3<Double>(0.0, 10.0, 20.0), SIMD3<Double>(0.0, 11.0, 21.0), SIMD3<Double>(0.0, 12.0, 20.0), SIMD3<Double>(20.0, 33.0, 59.0), SIMD3<Double>(21.0, 32.0, 56.0), SIMD3<Double>(59.0, 77.0, 101.0), SIMD3<Double>(58.0, 79.0, 100.0), SIMD3<Double>(58.0, 76.0, 102.0), SIMD3<Double>(300.0, 70.0, 20.0), SIMD3<Double>(500.0, 300.0, 202.0), SIMD3<Double>(500.0, 302.0, 204.0)]]

// outliers
[]
```
But there should be some outliers.

I found current version makes cluster labeled "nil", which means no-labeled points.
These need to be added to the outliers, so I updated some code of making clusters and outliers.


After updating,  We got here:
```
let (clusters, outliers) = dbscan(epsilon: 10,
                                    minimumNumberOfPoints: 3,
                                    distanceFunction: simd.distance)

// clusters
[[SIMD3<Double>(0.0, 10.0, 20.0), SIMD3<Double>(0.0, 11.0, 21.0), SIMD3<Double>(0.0, 12.0, 20.0)], [SIMD3<Double>(59.0, 77.0, 101.0), SIMD3<Double>(58.0, 79.0, 100.0), SIMD3<Double>(58.0, 76.0, 102.0)]]

// outliers
[SIMD3<Double>(20.0, 33.0, 59.0), SIMD3<Double>(21.0, 32.0, 56.0), SIMD3<Double>(300.0, 70.0, 20.0), SIMD3<Double>(500.0, 300.0, 202.0), SIMD3<Double>(500.0, 302.0, 204.0)]
```

Thank you for your great work!